### PR TITLE
Froze whoosh to 1.8.1 in requirements/prod.txt

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,4 +11,4 @@ pyopenssl
 requests>=0.9
 simplejson
 south>=0.7.3
-whoosh>=1.8.1
+whoosh==1.8.1


### PR DESCRIPTION
Higher versions of whoosh cause errors like -
     Error: No module named whoosh_backend

The pull request resolves such errors by freezing whoosh to 1.8.1 ; makes GWM run nicely.
