### PR TITLE
Add support for latest noVNC version.

### DIFF
--- a/ganeti_webmgr/static/js/noVNC.js
+++ b/ganeti_webmgr/static/js/noVNC.js
@@ -23,12 +23,12 @@ $(function () {
     // loaded function will be reset after noVNC scripts are loaded.
     var old = document.write;
     document.write = function(str) {$(document).append(str)};
-    document.write('<script type="text/javascript" src="'+INCLUDE_URI+'vnc.js"><//script>');
+    document.write('<script type="text/javascript" src="'+INCLUDE_URI+'util.js"><//script>');
     document.write = old;
 
-    // XXX manually call __initialize().  This normally happens onload, but
-    // won't work for us since document may have been loaded already
-    if (!Websock_native) {WebSocket.__initialize();}
+    // Load supporting scripts
+    Util.load_scripts(["webutil.js", "base64.js", "websock.js", "des.js",
+                       "input.js", "display.js", "jsunzip.js", "rfb.js"]);
 
     var rfb;
     var host, port, password; // VNC proxy connection settings

--- a/ganeti_webmgr/templates/ganeti/virtual_machine/novnc.html
+++ b/ganeti_webmgr/templates/ganeti/virtual_machine/novnc.html
@@ -4,7 +4,7 @@
 </style>
 <script type="text/javascript">
     // Set include path for noVNC scripts
-    var INCLUDE_URI = "{{SITE_ROOT}}/novnc/";
+    var INCLUDE_URI = "{{STATIC_URL}}/novnc/";
     // Set path for proxy requests
     var PROXY_REQUEST_URI = "{% url instance-vnc-proxy cluster_slug instance.hostname %}";
     {% if not popout %}


### PR DESCRIPTION
This small patch uses utils.js instead of vnc.js file (removed by upstream).
It also sets INCLUDE_URI to correct STATIC_URL variable in novnc.html template file.

This was tasted with latest noVNC and GWM code.

I've also made some changes in setup script and sent a pull request.
https://github.com/pbanaszkiewicz/ganeti_webmgr-setup/pull/9

I believe this patch closes: https://code.osuosl.org/issues/15189
