### PR TITLE
fixed some undefined parameter errors in template deployment

### DIFF
--- a/ganeti_web/backend/templates.py
+++ b/ganeti_web/backend/templates.py
@@ -85,7 +85,8 @@ def template_to_instance(template, hostname, owner):
     }
 
     hvparams = {}
-    hv = template.hypervisor
+    info = cluster.info
+    hv = info['default_hypervisor']
     kvm = hv == 'kvm'
     pvm = hv == 'xen-pvm'
     hvm = hv == 'xen-hvm'
@@ -122,7 +123,7 @@ def template_to_instance(template, hostname, owner):
         "name_check": template.name_check,
         "beparams": beparams,
         "no_install": template.no_install,
-        "start": not template.no_start,
+        "start": template.start,
         "hvparams": hvparams,
     }
 


### PR DESCRIPTION
I had some problems when installing an instance from a template. Some parameters where not found. 
