### PR TITLE
Use xen-hvm for VMWizardHVMForm

### DIFF
--- a/ganeti_webmgr/virtualmachines/forms.py
+++ b/ganeti_webmgr/virtualmachines/forms.py
@@ -1040,7 +1040,7 @@ class VMWizardHVMForm(Form):
             return
 
         self.cluster = cluster
-        params = cluster.info["hvparams"]["xen-pvm"]
+        params = cluster.info["hvparams"]["xen-hvm"]
 
         self.fields["boot_order"].initial = params["boot_order"]
         self.fields["disk_type"].initial = params["disk_type"]


### PR DESCRIPTION
This fixes https://code.osuosl.org/issues/18135.

@ramereth can you confirm that we're supposed to have boot_order on HVM, and not PVM? My research shows that this is correct, but it'd be nice to confirm.

@Kennric after this, I'd like to cut 0.11.1-rc1. Thoughts?