### PR TITLE
Bump requests version

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,7 +3,7 @@ django-fields==0.2.1
 django-haystack==1.2.1
 django-registration>=0.7,<0.8
 django-tables2==0.13.0
-requests==1.2.3
+requests>=2.7.0
 simplejson==3.3.0
 South==0.8.4
 Whoosh==1.8.1


### PR DESCRIPTION
This should address #28 on GitHub. The requests API has not changed and the new
version of requests has a newer urllib3 library.
I pinned the version to >=2.7.0 because I don't think that breaking changes
will be made to this package. Frankly I don't know why this package isn't in
the standard library.