### PR TITLE
Upgrade docs requirements

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,3 @@
-Jinja2==2.6
-Pygments==1.6
-Sphinx==1.1.3
+Jinja2==2.7.1
+Pygments==2.0.2
+Sphinx==1.3.1


### PR DESCRIPTION
This fixes Read the Docs.

Which has been broken for months.

It generates a custom ``conf.py`` using some properties that don't exist in Sphinx 1.1.3.