### PR TITLE
update config.yml

### DIFF
--- a/ganeti_webmgr/ganeti_web/settings/config.yml.dist
+++ b/ganeti_webmgr/ganeti_web/settings/config.yml.dist
@@ -16,8 +16,7 @@ DATABASES:
         NAME: /opt/ganeti_webmgr/ganeti.db
         USER:      # Not used with sqlite3.
         PASSWORD:  # Not used with sqlite3.
-        HOST:      # Set to empty string for localhost.
-                         # Not used with sqlite3.
+        HOST:      # Not used with sqlite3.
         PORT:      # Set to empty string for default.
                          #Not used with sqlite3.
 ##### End Database Configuration #####
@@ -34,7 +33,7 @@ DATETIME_FORMAT: "d/m/Y H:i"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE: "en-US"
+LANGUAGE_CODE: "en_US"
 ##### End Locale Configuration #####
 
 # Enable i18n (translations) and l10n (locales, currency, times).

--- a/ganeti_webmgr/ganeti_web/settings/config.yml.dist
+++ b/ganeti_webmgr/ganeti_web/settings/config.yml.dist
@@ -106,4 +106,4 @@ VNC_PROXY: "localhost:8888"
 
 # This is how long gwm will wait before timing out when requesting data from the
 # ganeti cluster.
-RAPI_CONNECT_TIMEOUT: 3
+RAPI_CONNECT_TIMEOUT: 60


### PR DESCRIPTION
This fixes two minor issues I found when setting up GWM from scratch the way Daniel Townend did on the mailing list:

```
apt-get install python-dev libffi-dev libmysqlclient-dev mysql-server -y
cd ~ && git clone -b develop https://github.com/osuosl/ganeti_webmgr.git
cd ganeti_webmgr
./scripts/setup.sh -D mysql
cp ~/ganeti_webmgr/scripts/vncauthproxy/init-ubuntu /etc/init.d/vncauthproxy
pip install service_identity
cp /root/ganeti_webmgr/ganeti_webmgr/ganeti_web/settings/config.yml.dist /opt/ganeti_webmgr/config/config.yml
# Set up database
mysql
CREATE DATABASE ganeti_webmgr;
CREATE USER 'ganeti_webmgr'@'localhost' IDENTIFIED BY '<password>';
GRANT ALL PRIVILEGES ON ganeti_webmgr.* TO 'ganeti_webmgr'@'localhost';
FLUSH PRIVILEGES;
exit
vi /opt/ganeti_webmgr/config/config.yml
# Finish configuring
source /opt/ganeti_webmgr/bin/activate
export DJANGO_SETTINGS_MODULE="ganeti_webmgr.ganeti_web.settings"
django-admin.py $CMD --settings "ganeti_webmgr.ganeti_web.settings"

(ganeti_webmgr)root@ganetiweb:~# django-admin.py syncdb --migrate
```

(For installing on a stock Ubuntu 14.04 image, you'll also need to install ``libssl-dev`` before running the setup script.)

This fixes:

1. default language code doesn't exist, causing the i18n system to error
2. can't set HOST to nothing if you're using SQL -- the comment was right, it should be "" (empty string), but I feel that's more confusing than helpful. They can explicitly set it to localhost, or if they know more about django they can try out "".