### PR TITLE
Update documentation links and setup.py.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,9 @@ Links
 * `Twitter <http://twitter.com/ganetiwebmgr>`_
 * IRC: ``#ganeti-webmgr`` on freenode.net
 
-.. _installation: http://ganeti-webmgr.readthedocs.org/en/latest/installing.html
-.. _compatibility: http://ganeti-webmgr.readthedocs.org/en/latest/ref/dependencies.html#compatibility
-.. _requirements: http://ganeti-webmgr.readthedocs.org/en/latest/ref/dependencies.html#dependencies
+.. _installation: http://ganeti-webmgr.readthedocs.org/en/latest/getting_started/installing.html
+.. _compatibility: http://ganeti-webmgr.readthedocs.org/en/latest/project_info/compatibility.html
+.. _requirements: http://ganeti-webmgr.readthedocs.org/en/latest/getting_started/requirements.html
 .. _Documentation: http://ganeti-webmgr.readthedocs.org/en/latest
 
 .. |gwm| replace:: Ganeti Web Manager

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -228,9 +228,11 @@ if [ $no_dependencies -eq 0 ]; then
     # debian based build_requirements
     if [ \( "$os" == "ubuntu" -o "$os" == "debian" \) ]; then
         build_requirements='python-dev build-essential libffi-dev libssl-dev'
-	else
-		build_requirements='' # fill me in for other platforms
-	fi
+
+    # RHEL based build_requirements
+    elif [ \( "$os" == "centos" \) ]; then
+        build_requirements='python-devel libffi-devel openssl-devel gcc'
+    fi
 
     # debian based && postgresql
     if [ \( "$os" == "ubuntu" -o "$os" == "debian" \) -a "$database_server" == "postgresql" ]; then
@@ -250,8 +252,8 @@ if [ $no_dependencies -eq 0 ]; then
     fi
 
     ${sudo} ${package_manager} ${package_manager_cmds} \
-		${build_requirements} python python-virtualenv \
-		${database_requirements}
+        ${build_requirements} python python-virtualenv \
+        ${database_requirements}
 
     # check whether installation succeeded
     if [ ! $? -eq 0 ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -243,6 +243,7 @@ if [ $no_dependencies -eq 0 ]; then
     fi
 
     ${sudo} ${package_manager} ${package_manager_cmds} python \
+		build-essential libssl-dev \
         python-virtualenv ${database_requirements}
 
     # check whether installation succeeded
@@ -273,7 +274,7 @@ check_if_exists "$venv"
 if [ $upgrade -eq 0 ]; then
     echo "Installing to: $install_directory"
 
-    ${venv} --setuptools --no-site-packages "$install_directory"
+    ${sudo} ${venv} --setuptools --no-site-packages "$install_directory"
     # check if virtualenv has succeeded
     if [ ! $? -eq 0 ]; then
         echo "${txtboldred}Something went wrong. Could not create virtual" \
@@ -296,7 +297,7 @@ fi
 ### updating pip and setuptools to the newest versions, installing wheel
 pip="$install_directory/bin/pip"
 check_if_exists "$pip"
-${pip} install $pip_proxy --upgrade setuptools pip wheel
+${sudo} ${pip} install $pip_proxy --upgrade setuptools pip wheel
 echo
 
 # check if successfully upgraded pip and setuptools
@@ -319,7 +320,7 @@ echo "------------------------------------------------------------------------"
 # WARNING: watch out for double slashes when concatenating these strings!
 url="$base_url/$os/$os_codename/$architecture/"
 
-${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" "$gwm_location"
+${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" "$gwm_location"
 
 if [ ! $? -eq 0 ]; then
     echo "${txtboldred}Something went wrong. Could not install GWM nor its" \
@@ -335,10 +336,10 @@ fi
 if [ "$database_server" != "sqlite" ]; then
     case $database_server in
         postgresql)
-            ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" psycopg2
+            ${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" psycopg2
             ;;
         mysql)
-            ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" MySQL-python
+            ${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" MySQL-python
             ;;
     esac
 
@@ -364,7 +365,7 @@ if [ -d "$config_dir" ]; then
     echo "Config directory at $config_dir already exists, not creating it."
 else
     echo "Config directory at $config_dir doesn't exist. Creating it."
-    mkdir -p "$config_dir"
+    ${sudo} mkdir -p "$config_dir"
 
     if [ ! $? -eq 0 ]; then
         echo "Unable to make default config directory at "

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -225,13 +225,20 @@ if [ $no_dependencies -eq 0 ]; then
     sudo="/usr/bin/sudo"
     check_if_exists "$sudo"
 
+    # debian based build_requirements
+    if [ \( "$os" == "ubuntu" -o "$os" == "debian" \) ]; then
+        build_requirements='python-dev build-essential libffi-dev libssl-dev'
+	else
+		build_requirements='' # fill me in for other platforms
+	fi
+
     # debian based && postgresql
     if [ \( "$os" == "ubuntu" -o "$os" == "debian" \) -a "$database_server" == "postgresql" ]; then
         database_requirements='libpq5'
 
     # debian based && mysql
     elif [ \( "$os" == "ubuntu" -o "$os" == "debian" \) -a "$database_server" == "mysql" ]; then
-        database_requirements='libmysqlclient18'
+        database_requirements='libmysqlclient18 libmysqlclient-dev'
 
     # RHEL based && postgresql
     elif [ \( "$os" == "centos" \) -a "$database_server" == "postgresql" ]; then
@@ -242,9 +249,9 @@ if [ $no_dependencies -eq 0 ]; then
         database_requirements='mysql-libs'
     fi
 
-    ${sudo} ${package_manager} ${package_manager_cmds} python \
-		python-dev build-essential libssl-dev \
-        python-virtualenv ${database_requirements}
+    ${sudo} ${package_manager} ${package_manager_cmds} \
+		${build_requirements} python python-virtualenv \
+		${database_requirements}
 
     # check whether installation succeeded
     if [ ! $? -eq 0 ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -243,7 +243,7 @@ if [ $no_dependencies -eq 0 ]; then
     fi
 
     ${sudo} ${package_manager} ${package_manager_cmds} python \
-		build-essential libssl-dev \
+		python-dev build-essential libssl-dev \
         python-virtualenv ${database_requirements}
 
     # check whether installation succeeded


### PR DESCRIPTION
I was going to submit the setup.sh changes via a separate PR.  That patch does:
1) Adds build-essential and libssl-dev to the install dependencies, per issue #69 
2) Uses sudo .. the virtualenv command for me failed because it couldn't write /opt.