### PR TITLE
Remove ~ line from vncauthproxy/init-systemd

### DIFF
--- a/scripts/vncauthproxy/init-systemd
+++ b/scripts/vncauthproxy/init-systemd
@@ -13,4 +13,3 @@ ExecStart=/opt/ganeti_webmgr/bin/twistd --pidfile=${PIDFILE} --nodaemon --logfil
 [Install]
 WantedBy=multi-user.target
 Alias=vncauthproxy.service
-~


### PR DESCRIPTION
Seems to be a copy/paste issue (from vim?). I couldn't enable vncauthproxy with it in the file.