### PR TITLE
update wheels, wheel docs

### DIFF
--- a/docs/source/deployment/intro.rst
+++ b/docs/source/deployment/intro.rst
@@ -5,7 +5,7 @@ Deployment Intro
 ================
 
 |gwm| supports various methods of deployment. By default Django ships with a
-simple python web server for development purposes. If your just trying to get
+simple python web server for development purposes. If you're just trying to get
 |gwm| up and running, or you simply want to contribute to the project then using
 the :ref:`development-server` is probably your best bet. Otherwise check out
 :ref:`static-files`. Once you've gotten your static files figured out, move into

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -31,7 +31,8 @@ Final Release Tasks
 Creating a final release consists of the following tasks.
 
 #. All issues for the release version should be resolved and closed
-#. Build and upload Python ``wheels`` for all requirements (see `building wheels`_)
+#. Build and upload Python ``wheels`` for all requirements (see `building wheels`_).
+    Don't forget to build the ``psycopg2`` and ``MySQL-python`` wheels!
 #. Bump version in ``docs/source/conf.py``, ``scripts/setup.sh``, and in
     ``ganeti_webmgr/constants.py``
 #. Create a release tag for this version, e.g. 0.11.2

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -30,9 +30,51 @@ Final Release Tasks
 
 Creating a final release consists of the following tasks.
 
-1. All issues for the release version should be resolved and closed
-2. Bump version in docs/source/conf.py and in ganeti_webmgr/constants.py
-3. Create a release tag for this version, e.g. 0.10.2
-4. Create a tar file for this release and upload it to Github's Releases.
-5. Create a Python package from the tag
-6. Announce the new release to the mailing list and IRC channels
+#. All issues for the release version should be resolved and closed
+#. Build and upload Python ``wheels`` for all requirements (see :ref:`building-wheels`)
+#. Bump version in docs/source/conf.py and in ganeti_webmgr/constants.py
+#. Create a release tag for this version, e.g. 0.10.2
+#. Create a tar file for this release and upload it to Github's Releases.
+#. Create a Python package from the tag
+#. Announce the new release to the mailing list and IRC channels
+
+
+.. _building-wheels:
+
+Building Wheels
+---------------
+
+Building ``wheels`` ensures that all instances of Ganeti Web Manager run the
+same version of all of its dependencies. Currently, wheels for Centos 6 and
+Centos 7 are provided; be sure to build wheels for both systems.
+
+To build wheels, create a virtual machine running the OS you're building for.
+Log into the machine, and install any dependencies needed.
+
+First, ``git`` and the ``epel`` repositories::
+
+    $ yum install -y git
+    $ wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-CENTOS_VERSION.noarch.rpm
+    $ rpm -ivh epel-release-latest.noarch.rpm
+
+Then, build dependencies::
+
+    $ yum install -y gcc openssl-devel python-devel libffi-devel python-pip
+    $ pip install wheel
+
+Clone |gwm| and build its wheels::
+
+    $ git clone https://github.com/osuosl/ganeti_webmgr.git
+    $ cd ganeti_webmgr
+    $ git checkout develop
+
+Finally, build the wheels::
+
+    $ pip wheel -r requirements/production.txt
+
+.. warning:: Django 1.4 does not support being built as a wheel. The
+    ``setup.sh`` script will fall back to installing it from ``pip`` if it isn't
+    available from the wheel source, so it is safe to not include it.
+
+The built wheels are put into ``wheelhouse/``. Tar up this directory and have it
+uploaded to ``/pub/osl/ganeti-webmgr/`` on ``ftp.osuosl.org``.

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -31,60 +31,11 @@ Final Release Tasks
 Creating a final release consists of the following tasks.
 
 #. All issues for the release version should be resolved and closed
-#. Build and upload Python ``wheels`` for all requirements (see :ref:`building-wheels`)
+#. Build and upload Python ``wheels`` for all requirements (see `building wheels`_)
 #. Bump version in docs/source/conf.py and in ganeti_webmgr/constants.py
 #. Create a release tag for this version, e.g. 0.10.2
 #. Create a tar file for this release and upload it to Github's Releases.
 #. Create a Python package from the tag
 #. Announce the new release to the mailing list and IRC channels
 
-
-.. _building-wheels:
-
-Building Wheels
----------------
-
-Building ``wheels`` ensures that all instances of Ganeti Web Manager run the
-same version of all of its dependencies. Currently, wheels for Centos 6, Centos
-7, Debian 7, and Debian 8 are provided; be sure to build wheels for all systems.
-
-To build wheels, create a virtual machine running the OS you're building for.
-Log into the machine, and install any dependencies needed.
-
-CentOS dependencies
-~~~~~~~~~~~~~~~~~~~
-
-First, ``git`` and the ``epel`` repositories::
-
-    $ yum install -y git
-    $ wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-CENTOS_VERSION.noarch.rpm
-    $ rpm -ivh epel-release-latest.noarch.rpm
-
-Then, build dependencies::
-
-    $ yum install -y gcc openssl-devel python-devel libffi-devel python-pip
-
-Debian dependencies
-~~~~~~~~~~~~~~~~~~~
-
-// TODO
-
-Building the wheels
-
-Clone |gwm| and build its wheels::
-
-    $ git clone https://github.com/osuosl/ganeti_webmgr.git
-    $ cd ganeti_webmgr
-    $ git checkout develop
-
-Finally, build the wheels::
-
-    $ pip install wheel
-    $ pip wheel -r requirements/production.txt
-
-.. warning:: Django 1.4 does not support being built as a wheel. The
-    ``setup.sh`` script will fall back to installing it from ``pip`` if it isn't
-    available from the wheel source, so it is safe to not include it.
-
-The built wheels are put into ``wheelhouse/``. Tar up this directory and have it
-uploaded to ``/pub/osl/ganeti-webmgr/`` on ``ftp.osuosl.org``.
+.. _`building wheels`: http://wiki.osuosl.org/howtos/wheels.html

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -32,8 +32,9 @@ Creating a final release consists of the following tasks.
 
 #. All issues for the release version should be resolved and closed
 #. Build and upload Python ``wheels`` for all requirements (see `building wheels`_)
-#. Bump version in docs/source/conf.py and in ganeti_webmgr/constants.py
-#. Create a release tag for this version, e.g. 0.10.2
+#. Bump version in ``docs/source/conf.py``, ``scripts/setup.sh``, and in
+    ``ganeti_webmgr/constants.py``
+#. Create a release tag for this version, e.g. 0.11.2
 #. Create a tar file for this release and upload it to Github's Releases.
 #. Create a Python package from the tag
 #. Announce the new release to the mailing list and IRC channels

--- a/docs/source/dev/release.rst
+++ b/docs/source/dev/release.rst
@@ -45,11 +45,14 @@ Building Wheels
 ---------------
 
 Building ``wheels`` ensures that all instances of Ganeti Web Manager run the
-same version of all of its dependencies. Currently, wheels for Centos 6 and
-Centos 7 are provided; be sure to build wheels for both systems.
+same version of all of its dependencies. Currently, wheels for Centos 6, Centos
+7, Debian 7, and Debian 8 are provided; be sure to build wheels for all systems.
 
 To build wheels, create a virtual machine running the OS you're building for.
 Log into the machine, and install any dependencies needed.
+
+CentOS dependencies
+~~~~~~~~~~~~~~~~~~~
 
 First, ``git`` and the ``epel`` repositories::
 
@@ -60,7 +63,13 @@ First, ``git`` and the ``epel`` repositories::
 Then, build dependencies::
 
     $ yum install -y gcc openssl-devel python-devel libffi-devel python-pip
-    $ pip install wheel
+
+Debian dependencies
+~~~~~~~~~~~~~~~~~~~
+
+// TODO
+
+Building the wheels
 
 Clone |gwm| and build its wheels::
 
@@ -70,6 +79,7 @@ Clone |gwm| and build its wheels::
 
 Finally, build the wheels::
 
+    $ pip install wheel
     $ pip wheel -r requirements/production.txt
 
 .. warning:: Django 1.4 does not support being built as a wheel. The

--- a/docs/source/getting_started/installing.rst
+++ b/docs/source/getting_started/installing.rst
@@ -21,7 +21,8 @@ operating system, installs required dependencies (even for your database of
 choice!), creates Python virtual environment and finally installs |gwm| with its
 own dependencies.
 
-#. Make sure that all |gwm|'s :ref:`requirements` are met.
+#. Make sure that all |gwm|'s :ref:`requirements` are met. For non-CentOS and
+   non-Debian machines, make sure to see :ref:`other_platforms`.
 
 #. Next you need the latest release of |gwm| which is |release|. You can
    download that here: |release_tarball|. You can also clone the repo and
@@ -61,12 +62,11 @@ own dependencies.
   .. Note:: You will likely need to run this as root as it requires permissions
           to install packages and create directories in ``/opt``.
 
-  .. Warning:: The script installs pre-compiled Python wheel packages for
-          CentOS 6, CentOS 7, Debian 7, and Debian 8. For Ubuntu, it will
-          attempt to install ``gcc`` and other compilation
-          requirements, and will download and install the Python requirements
-          from ``PyPi`` with ``pip``.
+  .. Warning:: For CentOS 6, the `EPEL repository`_ must be installed to use
+          ``python-virtualenv``. If you do not want to install EPEL, manually
+          install ``python-virtualenv`` and pass the ``-N`` flag to ``setup.sh``.
 
+.. _EPEL repository: https://fedoraproject.org/wiki/EPEL
 .. _vncauthproxy-script:
 
 VNC AuthProxy startup script

--- a/docs/source/getting_started/installing.rst
+++ b/docs/source/getting_started/installing.rst
@@ -61,6 +61,12 @@ own dependencies.
   .. Note:: You will likely need to run this as root as it requires permissions
           to install packages and create directories in ``/opt``.
 
+  .. Warning:: The script installs pre-compiled Python wheel packages for
+          CentOS 6, CentOS 7, Debian 7, and Debian 8. For Ubuntu, it will
+          attempt to install ``gcc`` and other compilation
+          requirements, and will download and install the Python requirements
+          from ``PyPi`` with ``pip``.
+
 .. _vncauthproxy-script:
 
 VNC AuthProxy startup script

--- a/docs/source/getting_started/requirements.rst
+++ b/docs/source/getting_started/requirements.rst
@@ -15,12 +15,30 @@ Base
 ~~~~
 
 * sudo
-* Python >= 2.6
-* Python Virtualenv
 * git
 
 These dependencies are required to install |gwm| via ``setup.sh`` installation
 script.  Follow up to :ref:`installation instructions <installation>`.
+
+During installation, if ``python`` and ``python-virtualenv`` are not installed,
+they will be installed.
+
+.. _other_platforms:
+
+Other Platforms
+```````````````
+
+For operating systems other than CentOS and Debian, it will be necessary to
+install several required packages that the script handles, specifically:
+
+* Python
+* ``python-virtualenv``
+
+Virtualenv is used to manage |gwm|'s dependencies without touching other
+software on the system.
+
+When running the ``setup.sh`` script, pass the ``-N`` flag to disable
+installation of these packages.
 
 Databases
 ~~~~~~~~~

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -62,7 +62,7 @@ gwm_location="$script_location/.."
 
 # helper function: display help message
 usage() {
-echo "Install (or upgrade) fresh Ganeti Web Manager from ganeti_webmgrSUOSL servers.
+echo "Install (or upgrade) Ganeti Web Manager from OSUOSL servers.
 
 Usage:
     $0 -h
@@ -202,9 +202,6 @@ if [ $no_dependencies -eq 0 ]; then
             package_manager_cmds='install -y'
             check_if_exists "/usr/bin/$package_manager"
             ;;
-
-        unknown)
-            # unknown Linux distribution
             echo "${txtboldred}Unknown distribution! Cannot install required" \
                  "dependencies!"
             echo "Please install on your own:"
@@ -308,7 +305,7 @@ fi
 ### updating pip and setuptools to the newest versions, installing wheel
 pip="$install_directory/bin/pip"
 check_if_exists "$pip"
-${sudo} ${pip} install $pip_proxy --trusted-host ftp.osuosl.org --upgrade setuptools pip wheel
+${sudo} ${pip} install $pip_proxy --upgrade setuptools pip wheel
 echo
 
 # check if successfully upgraded pip and setuptools
@@ -331,7 +328,7 @@ echo "------------------------------------------------------------------------"
 # WARNING: watch out for double slashes when concatenating these strings!
 url="$base_url/$os/$os_codename/$architecture/"
 
-${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" "$gwm_location"
+${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --trusted-host ftp.osuosl.org --find-link="$url" "$gwm_location"
 
 if [ ! $? -eq 0 ]; then
     echo "${txtboldred}Something went wrong. Could not install GWM nor its" \
@@ -347,10 +344,10 @@ fi
 if [ "$database_server" != "sqlite" ]; then
     case $database_server in
         postgresql)
-            ${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" psycopg2
+            ${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --trusted-host ftp.osuosl.org --find-link="$url" psycopg2
             ;;
         mysql)
-            ${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --find-link="$url" MySQL-python
+            ${sudo} ${pip} install $pip_proxy --upgrade --use-wheel --trusted-host ftp.osuosl.org --find-link="$url" MySQL-python
             ;;
     esac
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,9 +17,9 @@
 # 4. installs newest ``pip`` and ``setuptools`` in that virtual environment
 #    (they're needed for ``wheel`` packages below)
 #
-# 5. installs GWM dependencies into that virtual environment (all of them will
-#    be provided as ``wheel`` binary packages, because GWM users might not be
-#    allowed to have ``gcc`` & co. installed)
+# 5. installs GWM dependencies into that virtual environment. (On Centos and
+#    Debian, all of them will be provided as ``wheel`` binary packages, because
+#    GWM users might not be allowed to have ``gcc`` & co. installed)
 #
 # 6. installs GWM itself into that virtual environment
 #
@@ -226,12 +226,12 @@ if [ $no_dependencies -eq 0 ]; then
     check_if_exists "$sudo"
 
     # debian based build_requirements
-    if [ \( "$os" == "ubuntu" -o "$os" == "debian" \) ]; then
+    if [ \( "$os" == "ubuntu" \) ]; then
         build_requirements='python-dev build-essential libffi-dev libssl-dev'
 
     # RHEL based build_requirements
     elif [ \( "$os" == "centos" \) ]; then
-        build_requirements='python-devel libffi-devel openssl-devel gcc'
+        build_requirements=''
     fi
 
     # debian based && postgresql
@@ -306,7 +306,7 @@ fi
 ### updating pip and setuptools to the newest versions, installing wheel
 pip="$install_directory/bin/pip"
 check_if_exists "$pip"
-${sudo} ${pip} install $pip_proxy --upgrade setuptools pip wheel
+${sudo} ${pip} install $pip_proxy --trusted-host ftp.osuosl.org --upgrade setuptools pip wheel
 echo
 
 # check if successfully upgraded pip and setuptools
@@ -381,4 +381,3 @@ else
         echo "$config_dir${textreset}"
     fi
 fi
-

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -226,15 +226,6 @@ if [ $no_dependencies -eq 0 ]; then
     sudo="/usr/bin/sudo"
     check_if_exists "$sudo"
 
-    # debian based build_requirements
-    if [ \( "$os" == "ubuntu" \) ]; then
-        build_requirements='python-dev build-essential libffi-dev libssl-dev'
-
-    # RHEL based build_requirements
-    elif [ \( "$os" == "centos" \) ]; then
-        build_requirements=''
-    fi
-
     # debian based && postgresql
     if [ \( "$os" == "ubuntu" -o "$os" == "debian" \) -a "$database_server" == "postgresql" ]; then
         database_requirements='libpq5'
@@ -253,8 +244,7 @@ if [ $no_dependencies -eq 0 ]; then
     fi
 
     ${sudo} ${package_manager} ${package_manager_cmds} \
-        ${build_requirements} python python-virtualenv \
-        ${database_requirements}
+        python python-virtualenv python-pip ${database_requirements}
 
     # check whether installation succeeded
     if [ ! $? -eq 0 ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -51,10 +51,12 @@ check_if_exists() {
     fi
 }
 
+version="0.11.2" # current version of GWM
+
 # default values
 install_directory='/opt/ganeti_webmgr'
 config_dir='/opt/ganeti_webmgr/config'
-base_url="http://ftp.osuosl.org/pub/osl/ganeti-webmgr"
+base_url="http://ftp.osuosl.org/pub/osl/ganeti-webmgr/$version"
 script_location=$(dirname $0)
 gwm_location="$script_location/.."
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -202,6 +202,8 @@ if [ $no_dependencies -eq 0 ]; then
             package_manager_cmds='install -y'
             check_if_exists "/usr/bin/$package_manager"
             ;;
+        unknown)
+            # unknown Linux distribution
             echo "${txtboldred}Unknown distribution! Cannot install required" \
                  "dependencies!"
             echo "Please install on your own:"


### PR DESCRIPTION
Adds docs about wheels, how they're used, how to build and deploy them.

Also updates the ``setup.sh`` to once again not install a compiler, unless you're on Ubuntu (the script only really supports Debian and Centos).

Should I remove the ubuntu compiler installation as well, and just add comments in the installation docs about how to install on Ubuntu? It would literally consist of a line saying "install these compiler deps, and then run setup.sh script."

it's also worth noting that the script will happily fall back onto installing things from PyPi -- this is actually being used right now for Django, since Django 1.4 doesn't support being wheelified. 

And **bold for importance**: I don't want this stuff on a non-https host. That makes pip angry and I have to add a flag to cancel the warning, and I really don't want to do that for things being installed across the web.

@Kennric @jordane Thoughts on the installation process, esp. on ubuntu, and on where to host the packages? And ideas for what to do with Django? I'm ok with leaving it as is.
