### PR TITLE
increase default timeout so that GWM can complete API calls

### DIFF
--- a/docs/source/getting_started/configuring.rst
+++ b/docs/source/getting_started/configuring.rst
@@ -292,7 +292,7 @@ out when requesting data from the ganeti cluster.
 
 ::
 
-    RAPI_CONNECT_TIMEOUT: 3
+    RAPI_CONNECT_TIMEOUT: 60
 
 Sample configuration
 --------------------

--- a/ganeti_webmgr/ganeti_web/settings/settings.py.dist
+++ b/ganeti_webmgr/ganeti_web/settings/settings.py.dist
@@ -160,7 +160,7 @@ VNC_PROXY = 'localhost:8888'
 # PyCurls default TIMEOUT in 7.21.6 defaults to 13 and CONNECTTIMEOUT to 78.
 # This is way too long to wait for incorrect or unresponsive ganeti clusters
 # when using the rapi for syncing and querying.
-RAPI_CONNECT_TIMEOUT = 3
+RAPI_CONNECT_TIMEOUT = 60
 
 # Used for CSRF protection. Use a 16 or 32 bit random string here.
 # Do not share this with anyone.
@@ -178,4 +178,3 @@ RAPI_CONNECT_TIMEOUT = 3
 
 # Uncomment the line below
 # WEB_MGR_API_KEY = "random_string_of_numbers_and_letters"
-


### PR DESCRIPTION
This will prevent others from having the same "bug" we had where pages would consistently take 25 seconds to load due to attempting to cache data.