### PR TITLE
set rapi timeout to 10 to avoid long queries timing out

### DIFF
--- a/docs/source/getting_started/configuring.rst
+++ b/docs/source/getting_started/configuring.rst
@@ -292,7 +292,7 @@ out when requesting data from the ganeti cluster.
 
 ::
 
-    RAPI_CONNECT_TIMEOUT: 3
+    RAPI_CONNECT_TIMEOUT: 10
 
 Sample configuration
 --------------------

--- a/ganeti_webmgr/ganeti_web/settings/base.py
+++ b/ganeti_webmgr/ganeti_web/settings/base.py
@@ -210,7 +210,7 @@ LANGUAGES = (
 LAZY_CACHE_REFRESH = 600000
 # Other GWM Stuff
 VNC_PROXY = 'localhost:8888'
-RAPI_CONNECT_TIMEOUT = 3
+RAPI_CONNECT_TIMEOUT = 10
 
 
 def create_secrets(folder='.secrets'):

--- a/ganeti_webmgr/ganeti_web/settings/config.yml.dist
+++ b/ganeti_webmgr/ganeti_web/settings/config.yml.dist
@@ -106,4 +106,4 @@ VNC_PROXY: "localhost:8888"
 
 # This is how long gwm will wait before timing out when requesting data from the
 # ganeti cluster.
-RAPI_CONNECT_TIMEOUT: 60
+RAPI_CONNECT_TIMEOUT: 10

--- a/ganeti_webmgr/ganeti_web/settings/settings.py.dist
+++ b/ganeti_webmgr/ganeti_web/settings/settings.py.dist
@@ -160,7 +160,7 @@ VNC_PROXY = 'localhost:8888'
 # PyCurls default TIMEOUT in 7.21.6 defaults to 13 and CONNECTTIMEOUT to 78.
 # This is way too long to wait for incorrect or unresponsive ganeti clusters
 # when using the rapi for syncing and querying.
-RAPI_CONNECT_TIMEOUT = 3
+RAPI_CONNECT_TIMEOUT = 10
 
 # Used for CSRF protection. Use a 16 or 32 bit random string here.
 # Do not share this with anyone.
@@ -178,4 +178,3 @@ RAPI_CONNECT_TIMEOUT = 3
 
 # Uncomment the line below
 # WEB_MGR_API_KEY = "random_string_of_numbers_and_letters"
-


### PR DESCRIPTION
this will prevent caching queries from failing and rerunning on every
page load