### PR TITLE
Add missing global statements to make SECRET_KEY and WEB_MGR_API_KEY work

### DIFF
--- a/ganeti_webmgr/ganeti_web/settings/base.py
+++ b/ganeti_webmgr/ganeti_web/settings/base.py
@@ -199,6 +199,9 @@ RAPI_CONNECT_TIMEOUT = 3
 
 
 def create_secrets(folder='.secrets'):
+    global SECRET_KEY
+    global WEB_MGR_API_KEY
+
     # Generate a secret key, and store it in a file to be read later.
     secrets_folder = join(DEFAULT_INSTALL_PATH, folder)
 


### PR DESCRIPTION
When the keys are to be created in the .secrets folder and not stored in the config.yml
file, base.py generates them and tries to assign to the global variables
SECRET_KEY and WEB_MGR_API_KEY so that the settings are complete. However this does
not work because the necessary `global` statements are missing, so the assignment is
to a local variable and does not go into the settings.

This causes the initial `syncdb --migrate` during installation (following the
instructions) to fail with this error:

	$ sudo /opt/ganeti_webmgr/bin/django-admin.py syncdb --migrate --settings=ganeti_webmgr.ganeti_web.settings
	Traceback (most recent call last):
	  File "/opt/ganeti_webmgr/bin/django-admin.py", line 5, in <module>
	    management.execute_from_command_line()
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
	    utility.execute()
	  ...
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/ganeti_webmgr/ganeti_web/search_indexes.py", line 3, in <module>
	    from ganeti_webmgr.virtualmachines.models import VirtualMachine
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/ganeti_webmgr/virtualmachines/models.py", line 5, in <module>
	    from ganeti_webmgr.clusters.models import CachedClusterObject
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/ganeti_webmgr/clusters/models.py", line 297, in <module>
	    class Cluster(CachedClusterObject):
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/ganeti_webmgr/clusters/models.py", line 309, in Cluster
	    max_length=128, blank=True)
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/django_fields/fields.py", line 50, in __init__
	    self.cipher = self.cipher_object.new(settings.SECRET_KEY[:32])
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/Crypto/Cipher/AES.py", line 95, in new
	    return AESCipher(key, *args, **kwargs)
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/Crypto/Cipher/AES.py", line 59, in __init__
	    blockalgo.BlockAlgo.__init__(self, _AES, key, *args, **kwargs)
	  File "/opt/ganeti_webmgr/local/lib/python2.7/site-packages/Crypto/Cipher/blockalgo.py", line 141, in __init__
	    self._cipher = factory.new(key, *args, **kwargs)
	ValueError: Key cannot be the null string

This patch adds the missing global statements.

You might want to consider using Travis CI to ensure that the installation process stays well-tested?