### PR TITLE
Fix main float wrapper width for chrome

### DIFF
--- a/ganeti_webmgr/static/css/base.css
+++ b/ganeti_webmgr/static/css/base.css
@@ -95,7 +95,7 @@ pre.error {
 
 #body_wrapper {
     min-height: 100%; /* Sticky footer */
-    width:979px;
+    width:980px;
     margin:0 auto;
 }
 
@@ -120,7 +120,7 @@ pre.error {
 #logo {display:block; margin-left:145px;}
 
 #content_wrapper {background:#eee; width:100%;}
-#content_column {margin: 0 auto; width:979px;}
+#content_column {margin: 0 auto; width:980px;}
 #content {
     background:white;
     border-left: 1px solid #DDDDDD;
@@ -224,7 +224,7 @@ pre.error {
     position:relative; /* Sticky Footer */
     padding: 5px 0 0 0;
     text-align: center;
-    min-width:979px;
+    min-width:980px;
     width: 100%;
 }
 #footer a {color:#C16328;}


### PR DESCRIPTION
The float container width forces the floated elements to stack on chrome using the current width. Increasing the float container width by 1 pixel fixes this problem, which was most likely caused by a rounding error. This change does not require documentation as it is a small CSS error correction.

## Before
![2016-10-18-163842_905x674_scrot](https://cloud.githubusercontent.com/assets/10211727/19500384/840df892-9551-11e6-8361-e398551cb344.png)
## After
![2016-10-18-163909_909x513_scrot](https://cloud.githubusercontent.com/assets/10211727/19500392/89248b98-9551-11e6-8264-505b32199f53.png)
