### PR TITLE
Fix recent setup failures.

### DIFF
--- a/chef/environments/vagrant.json
+++ b/chef/environments/vagrant.json
@@ -18,6 +18,7 @@
         "host": "localhost",
         "port": 3306
       },
+      "path": "/home/vagrant/ganeti_webmgr",
       "apache": {
         "server_aliases": ["localhost"]
       },

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -274,7 +274,8 @@ check_if_exists "$venv"
 if [ $upgrade -eq 0 ]; then
     echo "Installing to: $install_directory"
 
-    ${sudo} ${venv} --setuptools --no-site-packages "$install_directory"
+    ${sudo} ${venv} --no-site-packages "$install_directory"
+    echo "Ran venv."
     # check if virtualenv has succeeded
     if [ ! $? -eq 0 ]; then
         echo "${txtboldred}Something went wrong. Could not create virtual" \
@@ -294,10 +295,23 @@ else
     # automatically.
 fi
 
-### updating pip and setuptools to the newest versions, installing wheel
+### first install a local setuptools to bootstrap everything
+python="/usr/bin/python"
+${python} -m ensurepip --user
+echo
+
+### then install pip, which depends on setuptools, and can install the rest
 pip="$install_directory/bin/pip"
 check_if_exists "$pip"
-${sudo} ${pip} install $pip_proxy --upgrade setuptools pip wheel
+${sudo} ${pip} install ${pip_proxy} --upgrade pip
+echo
+
+### then install all of the dependencies of setuptools, which are cyclic
+${sudo} ${pip} install ${pip_proxy} --upgrade appdirs six pyparsing packaging
+echo
+
+### setuptools to the newest version, installing wheel
+${sudo} ${pip} install $pip_proxy --upgrade setuptools wheel
 echo
 
 # check if successfully upgraded pip and setuptools


### PR DESCRIPTION
Setuptools v34 introduced several new dependencies, which must each themselves be installed with setuptools, creating a cyclic dependency that makes the whole thing very difficult to install. In order to fix this, pip is first upgraded to the newest versions (which are smart enough to know not to call setuptools on itself now), then the dependencies for setuptools are installed using the old version of setuptools, then setuptools itself is updated. This prevents any further issues.

As well, there was an issue with changes to the application (namely to the setup.sh script) not being reflected on the vagrant instance I was using for testing. This was because Chef was installing the application to /opt/ganeti_webmgr_src, but the setup script was told to use /home/vagrant/ganeti_webmgr as the install directory. Once they were both back on the same page, this fixed the issue.