### PR TITLE
Lock Twisted-15.4.0 to continue support of python 2.6 on CentOS 6

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -13,3 +13,4 @@ django-object-log==0.7.1
 django-object-permissions==1.4.6
 pyyaml==3.11
 django-bower==5.0.4
+Twisted==15.4.0


### PR DESCRIPTION
Without this lock, we can't install ganeti_webmgr on CentOS 6.