### PR TITLE
Constrain pyopenssl to 17.5.0

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -11,5 +11,6 @@ django-include-strip-tag==0.1.0
 VNCAuthProxy==1.1.1
 django-object-log==0.7.1
 django-object-permissions==1.4.6
+pyopenssl==17.5.0
 pyyaml==3.11
 Twisted==15.4.0


### PR DESCRIPTION
VNCAuthProxy depends on pyopenssl but doesn't seem to constrain its version. The latest pyopenssl release requires a version of the cryptography package that's unavailable to Python 2.6/CentOS 6. 17.5.0 is the last compatible version of pyopenssl.